### PR TITLE
feat: Guardado en log de actividad

### DIFF
--- a/ExportReviewerCertificatePlugin.php
+++ b/ExportReviewerCertificatePlugin.php
@@ -16,9 +16,11 @@
 
 namespace APP\plugins\generic\exportReviewerCertificate;
 
+use APP\core\Application;
 use APP\file\PublicFileManager;
 use APP\i18n\AppLocale;
 use APP\plugins\generic\exportReviewerCertificate\controllers\tab\ExportReviewerCertificateSettingsTabFormHandler;
+use APP\plugins\generic\exportReviewerCertificate\repositories\ReviewerCertificateRepository;
 use PKP\components\forms\context\ExportReviewerCertificateForm;
 use PKP\core\Registry;
 use PKP\plugins\GenericPlugin;
@@ -58,6 +60,7 @@ class ExportReviewerCertificatePlugin extends GenericPlugin
       Hook::add('APIHandler::endpoints', [$this, 'callbackSetupEndpoints']);
       Hook::add('LoadHandler', [$this, 'setPageHandler']);
       Hook::add('TemplateResource::getFilename', [$this, '_overridePluginTemplates']);
+      Hook::add('TemplateManager::fetch', [$this, 'handleTemplateFetch']);
     }
 
     return $success;
@@ -253,6 +256,39 @@ class ExportReviewerCertificatePlugin extends GenericPlugin
       'apiSummary' => true,
       'validation' => ['nullable']
     ];
+
+    return false;
+  }
+
+  /**
+   * Hook callback: Assign variables to reviewCompleted.tpl template
+   * @param string $hookName
+   * @param array $args [$templateMgr, $template, $cache_id, $compile_id, &$result]
+   * @return bool
+   */
+  public function handleTemplateFetch($hookName, $args)
+  {
+    $templateMgr = $args[0];
+    $template = $args[1];
+
+    if (strpos($template, 'reviewCompleted.tpl') !== false) {
+      $request = Application::get()->getRequest();
+      $user = $request->getUser();
+      $submission = $templateMgr->getTemplateVars('submission');
+
+      if ($user && $submission) {
+        $repository = new ReviewerCertificateRepository();
+        $certificate = $repository->getReviewerCertificate(
+          $user->getId(),
+          $submission->getId()
+        );
+
+        $templateMgr->assign([
+          'certificateDownloaded' => !is_null($certificate),
+          'certificateDownloadDate' => $certificate ? $certificate['created_at'] : null
+        ]);
+      }
+    }
 
     return false;
   }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a OJS 3.4 plugin that allows reviewers to download evaluation completion
 ## Prerequisites
 
 - Open Journal Systems - OJS 3.4 [🌐 Information/Download link](https://pkp.sfu.ca/software/ojs/download/archive/) 
-- PHP 7.4|8+ 
+- PHP 8.0|8+ 
 - PHP GD extension 
 - Linux server is preferred
 
@@ -30,9 +30,9 @@ If you have server access, you can clone this repo into <ojs_root_dir>/plugins/g
 ```
 cd /<ojs_root_dir>/plugins/generic
 ```
-2. Clone this repo using **ojs34_export_reviewer_certificate_plugin** branch from plugin´s [github repository](https://github.com/epsomsegura/exportReviewerCertificate)
+2. Clone this repo using **ojs34_export_reviewer_certificate_plugin** branch from plugin´s [github repository](https://github.com/escire/ExportReviewerCertificatePlugin)
 ```
-git clone --branch ojs34_export_reviewer_certificate_plugin --single-branch https://github.com/epsomsegura/exportReviewerCertificate.git
+git clone --branch ojs34_export_reviewer_certificate_plugin --single-branch https://github.com/escire/ExportReviewerCertificatePlugin
 ```
 3. That´s all, now you can enable and configure the plugin to each journal
 

--- a/controllers/pdf/ExportReviewerCertificatePdfHandler.inc.php
+++ b/controllers/pdf/ExportReviewerCertificatePdfHandler.inc.php
@@ -19,11 +19,22 @@ use APP\facades\Repo;
 use APP\handler\Handler;
 use APP\i18n\AppLocale;
 use APP\plugins\generic\exportReviewerCertificate\PDFLib;
-use PKP\core\JSONMessage;
-use PKP\security\authorization\PolicySet;
-use PKP\security\Role;
-use PKP\security\authorization\RoleBasedHandlerOperationPolicy;
 use APP\plugins\generic\exportReviewerCertificate\repositories\ReviewerCertificateRepository;
+use PKP\core\Core;
+use PKP\core\JSONMessage;
+use PKP\core\PKPApplication;
+use PKP\db\DAORegistry;
+use PKP\file\FileManager;
+use PKP\log\event\PKPSubmissionEventLogEntry;
+use PKP\log\event\SubmissionFileEventLogEntry;
+use PKP\security\authorization\PolicySet;
+use PKP\security\authorization\RoleBasedHandlerOperationPolicy;
+use PKP\security\Role;
+use PKP\services\PKPFileService;
+use PKP\submissionFile\SubmissionFile;
+
+// Constante para el evento de descarga de certificado de revisor
+define('SUBMISSION_LOG_REVIEWER_CERTIFICATE_DOWNLOAD', 0x40000020);
 
 /**
  * @class ExportReviewerCertificatePdfHandler
@@ -86,29 +97,76 @@ class ExportReviewerCertificatePdfHandler extends Handler
 		$currentUser = $request->getUser();
 		$this->_request = $request;
 		$params = $request->_requestVars;
+		
 		// Validations
 		if (!$currentUser) {
-			return new JSONMessage("Error", "User is not logged in");
+			return new JSONMessage(false, __('plugins.generic.exportReviewerCertificate.error.notLoggedIn'));
 		}
 		if (!isset($params['submission'])) {
-			return new JSONMessage("Error", "Submission not setted");
+			return new JSONMessage(false, __('plugins.generic.exportReviewerCertificate.error.submissionNotSet'));
 		}
-		$this->review_certificate = $this->reviewCertificateRepository->getReviewerCertificate($currentUser->_data['id'], $params['submission']);
-
-		$this->certificate_dataset["reviewer_title"] = isset($params['reviewer_title']) ? $params['reviewer_title'] : "c.";
-		// Set reviewer data into certificate dataset
+		
+		// Check if certificate has already been downloaded
+		$this->review_certificate = $this->reviewCertificateRepository->getReviewerCertificate(
+			$currentUser->_data['id'], 
+			$params['submission']
+		);
+		
+		if ($this->review_certificate) {
+			$request->getSession()->setSessionVar(
+				'notification', 
+				__('plugins.generic.exportReviewerCertificate.certificate.alreadyDownloaded')
+			);
+			$request->redirect(null, 'reviewer', 'submission', $params['submission']);
+			return;
+		}
+		
+		$this->certificate_dataset["reviewer_title"] = isset($params['reviewer_title']) ? $params['reviewer_title'] : "C.";
+		
 		$this->reviewer();
-		// Set journal data into certificate dataset
 		$this->journal();
-		// Set submission data into certificate dataset
 		$this->submission($params['submission']);
-
-		if (!$this->review_certificate) {
-			$this->reviewCertificateRepository->registerReviewerCertificate($currentUser->_data['id'], $params['submission']);
-		}
-
+		
+		// Register certificate download before generating PDF
+		$this->reviewCertificateRepository->registerReviewerCertificate($currentUser->_data['id'], $params['submission']);
+		
+		// Obtener el submission
+		$submission = Repo::submission()->get($params['submission']);
+		
+		// Generar el PDF y obtener el contenido
 		import('plugins.generic.exportReviewerCertificate.src.PDFLib');
-		return (new PDFLib($this->certificate_dataset))->stream();
+		$pdfLib = new PDFLib($this->certificate_dataset);
+		$pdfContent = $pdfLib->output();
+		
+		// Save file and register in activity log
+		if ($submission) {
+			$submissionFile = $this->saveReviewerCertificatePDF($request, $submission, $currentUser, $pdfContent);
+			
+			if ($submissionFile) {
+				$reviewerName = str_replace(' ', '_', $currentUser->getFullName());
+				$fileName = 'certificado_revisor_' . $reviewerName . '_' . date('YmdHis') . '.pdf';
+				
+				$eventLog = Repo::eventLog()->newDataObject([
+					'assocType' => PKPApplication::ASSOC_TYPE_SUBMISSION,
+					'assocId' => $submission->getId(),
+					'eventType' => SUBMISSION_LOG_REVIEWER_CERTIFICATE_DOWNLOAD,
+					'userId' => $currentUser->getId(),
+					'message' => 'plugins.generic.exportReviewerCertificate.log.certificateDownloaded',
+					'isTranslated' => false,
+					'dateLogged' => Core::getCurrentDate(),
+					'reviewerName' => $currentUser->getFullName(),
+					'username' => $currentUser->getUsername(),
+					'filename' => $fileName
+				]);
+				Repo::eventLog()->add($eventLog);
+			}
+		}
+		
+		// Download PDF to browser
+		header('Content-Type: application/pdf');
+		header('Content-Disposition: inline; filename="' . $this->certificate_dataset['reviewer_fullname'] . '-certificate.pdf"');
+		echo $pdfContent;
+		exit;
 	}
 
 	/**
@@ -185,5 +243,65 @@ class ExportReviewerCertificatePdfHandler extends Handler
 	{
 		$month = strtolower(date('F', strtotime($date)));
 		return __('plugins.generic.exportReviewerCertificate.pdf.month.' . $month);
+	}
+
+	/**
+	 * Save reviewer certificate PDF to OJS file system
+	 * @param $request Request
+	 * @param $submission Submission
+	 * @param $reviewer User
+	 * @param $pdfContent string Binary PDF content
+	 * @return SubmissionFile|null
+	 */
+	private function saveReviewerCertificatePDF($request, $submission, $reviewer, $pdfContent)
+	{
+		try {
+			$reviewAssignmentDao = DAORegistry::getDAO('ReviewAssignmentDAO');
+			$reviewAssignments = $reviewAssignmentDao->getBySubmissionId($submission->getId());
+			
+			$reviewAssignment = null;
+			foreach ($reviewAssignments as $ra) {
+				if ($ra->getReviewerId() == $reviewer->getId() && $ra->getDateCompleted()) {
+					$reviewAssignment = $ra;
+					break;
+				}
+			}
+			
+			if (!$reviewAssignment) {
+				return null;
+			}
+			
+			$reviewerName = str_replace(' ', '_', $reviewer->getFullName());
+			$fileName = 'certificado_revisor_' . $reviewerName . '_' . date('YmdHis') . '.pdf';
+			
+			$tempFilePath = tempnam(sys_get_temp_dir(), 'cert');
+			file_put_contents($tempFilePath, $pdfContent);
+			
+			$context = $request->getContext();
+			$submissionDir = 'contexts/' . $context->getId() . '/submissions/' . $submission->getId() . '/';
+			$relativePath = $submissionDir . uniqid() . '.pdf';
+			
+			$fileService = app(PKPFileService::class);
+			$fileId = $fileService->add($tempFilePath, $relativePath);
+			
+			unlink($tempFilePath);
+			
+			$submissionFile = Repo::submissionFile()->newDataObject([
+				'fileId' => $fileId,
+				'fileStage' => SubmissionFile::SUBMISSION_FILE_REVIEW_ATTACHMENT,
+				'submissionId' => $submission->getId(),
+				'uploaderUserId' => $reviewer->getId(),
+				'assocType' => PKPApplication::ASSOC_TYPE_REVIEW_ASSIGNMENT,
+				'assocId' => $reviewAssignment->getId(),
+				'name' => ['en' => $fileName, 'es' => $fileName]
+			]);
+			
+			$submissionFileId = Repo::submissionFile()->add($submissionFile);
+			
+			return Repo::submissionFile()->get($submissionFileId);
+			
+		} catch (\Exception $e) {
+			return null;
+		}
 	}
 }

--- a/controllers/tab/ExportReviewerCertificateSettingsTabFormHandler.inc.php
+++ b/controllers/tab/ExportReviewerCertificateSettingsTabFormHandler.inc.php
@@ -126,15 +126,11 @@ class ExportReviewerCertificateSettingsTabFormHandler extends SettingsHandler
 	{
 		import('classes.file.PublicFileManager');
 		$publicFileManager = new PublicFileManager();
-//		error_log( print_r('*********Base Path**********', TRUE) );
 		$basePath = $this->request->getBasePath();
-		error_log( print_r($basePath, TRUE) );
-//		error_log( print_r('*********Get Path**********', TRUE) );
-                //error_log( print_r( __DIR__)[0] . $this->request->getBasePath() . '/public/journals/' . $this->context->getId() . '/' . $fileName, TRUE) );
+		
 		if (!empty($this->context->getId()) && !empty($basePath)) {
 			$filePath = explode($this->request->getBasePath(), __DIR__)[0] . $this->request->getBasePath() . '/public/journals/' . $this->context->getId() . '/' . $fileName;
 			$publicFileManager->deleteByPath($filePath);
 		}
-		//$publicFileManager->deleteByPath($filePath);
 	}
  }

--- a/locale/en/locale.po
+++ b/locale/en/locale.po
@@ -287,3 +287,27 @@ msgstr "thirty"
 
 msgid "plugins.generic.exportReviewerCertificate.pdf.day.text31"
 msgstr "thirty-one"
+
+# Certificate downloaded messages
+msgid "plugins.generic.exportReviewerCertificate.certificate.download"
+msgstr "Certificate downloaded"
+
+msgid "plugins.generic.exportReviewerCertificate.certificate.alreadyDownloaded"
+msgstr "You have already downloaded your reviewer certificate for this article. Only one download is allowed per completed review."
+
+msgid "plugins.generic.exportReviewerCertificate.certificate.downloadDate"
+msgstr "Download date: {$date}"
+
+# Log messages
+msgid "plugins.generic.exportReviewerCertificate.log.certificateUploaded"
+msgstr "Review file \"{$filename}\" uploaded as file {$fileId}."
+
+msgid "plugins.generic.exportReviewerCertificate.log.certificateDownloaded"
+msgstr "Reviewer {$reviewerName} ({$username}) downloaded their review certificate. File: {$filename}"
+
+# Error messages
+msgid "plugins.generic.exportReviewerCertificate.error.notLoggedIn"
+msgstr "You must be logged in to download the certificate."
+
+msgid "plugins.generic.exportReviewerCertificate.error.submissionNotSet"
+msgstr "No submission specified to download the certificate."

--- a/locale/es/locale.po
+++ b/locale/es/locale.po
@@ -290,3 +290,27 @@ msgstr "treinta"
 
 msgid "plugins.generic.exportReviewerCertificate.pdf.day.text31"
 msgstr "treinta y un"
+
+# Mensajes de certificado descargado
+msgid "plugins.generic.exportReviewerCertificate.certificate.download"
+msgstr "Certificado descargado"
+
+msgid "plugins.generic.exportReviewerCertificate.certificate.alreadyDownloaded"
+msgstr "Ya has descargado tu certificado de revisor para este artículo. Solo se permite una descarga por revisión completada."
+
+msgid "plugins.generic.exportReviewerCertificate.certificate.downloadDate"
+msgstr "Fecha de descarga: {$date}"
+
+# Mensajes de log
+msgid "plugins.generic.exportReviewerCertificate.log.certificateUploaded"
+msgstr "Se cargó la revisión \"{$filename}\" del archivo {$fileId}."
+
+msgid "plugins.generic.exportReviewerCertificate.log.certificateDownloaded"
+msgstr "El revisor {$reviewerName} ({$username}) descargó su certificado de revisión. Archivo: {$filename}"
+
+# Mensajes de error
+msgid "plugins.generic.exportReviewerCertificate.error.notLoggedIn"
+msgstr "Debe iniciar sesión para descargar el certificado."
+
+msgid "plugins.generic.exportReviewerCertificate.error.submissionNotSet"
+msgstr "No se ha especificado el envío para descargar el certificado."

--- a/repositories/ReviewerCertificateRepository.php
+++ b/repositories/ReviewerCertificateRepository.php
@@ -4,6 +4,8 @@
   *
   * Copyright (c) 2025 Oscar Chacón - eScire
   * oscar@escire.lat
+  * Copyright (c) 2025 Gustavo Casiano - eScire
+  * gustavo@escire.lat
   *
   * @class ReviewerCertificateRepository
   *
@@ -14,18 +16,37 @@ use Illuminate\Support\Facades\DB;
 
 class ReviewerCertificateRepository
 {
+	/**
+	 * Register a reviewer certificate
+	 * Checks if it already exists before inserting to avoid duplicates
+	 * @param int $userId User ID (reviewer)
+	 * @param int $submissionId Submission ID
+	 * @return bool True if created successfully or already exists
+	 */
 	public function registerReviewerCertificate($userId, $submissionId): bool
 	{
+		if ($this->exists($userId, $submissionId)) {
+			return true;
+		}
+
 		$sql = "INSERT INTO
 			review_certificates(user_id, submission_id, created_at, updated_at)
 			VALUES
 			(?, ?, ?, ?)";
 		$now = date('Y-m-d H:i:s');
-		$params = array_merge([$userId], [$submissionId], [$now], [$now]);
+		$params = [$userId, $submissionId, $now, $now];
+		
 		DB::insert($sql, $params);
-		return true;
+		
+		return $this->exists($userId, $submissionId);
 	}
 
+	/**
+	 * Get reviewer certificate by user and submission
+	 * @param int $userId User ID (reviewer)
+	 * @param int $submissionId Submission ID
+	 * @return array|null Array with data or null if not exists
+	 */
 	public function getReviewerCertificate($userId, $submissionId): ?array
 	{
 		$sql = "SELECT *
@@ -33,7 +54,7 @@ class ReviewerCertificateRepository
 			WHERE
 				user_id = ? AND
 				submission_id = ?";
-		$params = array_merge([$userId], [$submissionId]);
+		$params = [$userId, $submissionId];
 		$result = DB::select($sql, $params);
 
 		$returner = null;
@@ -42,5 +63,163 @@ class ReviewerCertificateRepository
 		}
 		unset($result);
 		return $returner;
+	}
+
+	/**
+	 * Check if certificate exists for user and submission
+	 * @param int $userId User ID
+	 * @param int $submissionId Submission ID
+	 * @return bool True if exists
+	 */
+	public function exists($userId, $submissionId): bool
+	{
+		$sql = "SELECT COUNT(*) as count
+			FROM review_certificates
+			WHERE
+				user_id = ? AND
+				submission_id = ?";
+		$params = [$userId, $submissionId];
+		$result = DB::select($sql, $params);
+
+		return !empty($result) && $result[0]->count > 0;
+	}
+
+	/**
+	 * Get certificate by ID
+	 * @param int $certificateId Certificate ID
+	 * @return array|null Array with data or null if not exists
+	 */
+	public function getById($certificateId): ?array
+	{
+		$sql = "SELECT *
+			FROM review_certificates
+			WHERE id = ?";
+		$params = [$certificateId];
+		$result = DB::select($sql, $params);
+
+		$returner = null;
+		if (!empty($result)) {
+			$returner = (array) $result[0];
+		}
+		unset($result);
+		return $returner;
+	}
+
+	/**
+	 * Get all certificates for a user
+	 * @param int $userId User ID
+	 * @return array Array of certificates
+	 */
+	public function getByUserId($userId): array
+	{
+		$sql = "SELECT *
+			FROM review_certificates
+			WHERE user_id = ?
+			ORDER BY created_at DESC";
+		$params = [$userId];
+		$result = DB::select($sql, $params);
+
+		$certificates = [];
+		if (!empty($result)) {
+			foreach ($result as $row) {
+				$certificates[] = (array) $row;
+			}
+		}
+		return $certificates;
+	}
+
+	/**
+	 * Get all certificates for a submission
+	 * @param int $submissionId Submission ID
+	 * @return array Array of certificates
+	 */
+	public function getBySubmissionId($submissionId): array
+	{
+		$sql = "SELECT *
+			FROM review_certificates
+			WHERE submission_id = ?
+			ORDER BY created_at DESC";
+		$params = [$submissionId];
+		$result = DB::select($sql, $params);
+
+		$certificates = [];
+		if (!empty($result)) {
+			foreach ($result as $row) {
+				$certificates[] = (array) $row;
+			}
+		}
+		return $certificates;
+	}
+
+	/**
+	 * Count certificates by user
+	 * @param int $userId User ID
+	 * @return int Certificate count
+	 */
+	public function countByUserId($userId): int
+	{
+		$sql = "SELECT COUNT(*) as count
+			FROM review_certificates
+			WHERE user_id = ?";
+		$params = [$userId];
+		$result = DB::select($sql, $params);
+
+		return !empty($result) ? (int) $result[0]->count : 0;
+	}
+
+	/**
+	 * Count certificates by submission
+	 * @param int $submissionId Submission ID
+	 * @return int Certificate count
+	 */
+	public function countBySubmissionId($submissionId): int
+	{
+		$sql = "SELECT COUNT(*) as count
+			FROM review_certificates
+			WHERE submission_id = ?";
+		$params = [$submissionId];
+		$result = DB::select($sql, $params);
+
+		return !empty($result) ? (int) $result[0]->count : 0;
+	}
+
+	/**
+	 * Delete certificate by user and submission
+	 * @param int $userId User ID
+	 * @param int $submissionId Submission ID
+	 * @return bool True if deleted successfully
+	 */
+	public function deleteByUserAndSubmission($userId, $submissionId): bool
+	{
+		$sql = "DELETE FROM review_certificates
+			WHERE user_id = ? AND submission_id = ?";
+		$params = [$userId, $submissionId];
+		DB::delete($sql, $params);
+		return true;
+	}
+
+	/**
+	 * Delete certificate by ID
+	 * @param int $certificateId Certificate ID
+	 * @return bool True if deleted successfully
+	 */
+	public function deleteById($certificateId): bool
+	{
+		$sql = "DELETE FROM review_certificates WHERE id = ?";
+		$params = [$certificateId];
+		DB::delete($sql, $params);
+		return true;
+	}
+
+	/**
+	 * Count all certificates
+	 * @return int Total certificates
+	 */
+	public function countAll(): int
+	{
+		$sql = "SELECT COUNT(*) as count FROM review_certificates";
+		$result = DB::select($sql);
+
+		return !empty($result) ? (int) $result[0]->count : 0;
 	}
 }

--- a/src/PDFLib.php
+++ b/src/PDFLib.php
@@ -64,6 +64,17 @@ class PDFLib
     }
 
     /**
+     * Output pdf content as string
+     * @return string PDF content
+     */
+    public function output(): string
+    {
+        $this->setHtmlString();
+        $this->pdf->render();
+        return $this->pdf->output();
+    }
+
+    /**
      * Create PDF Handler
      */
     private function createPDFHandler(): self

--- a/templates/reviewer/review/reviewCompleted.tpl
+++ b/templates/reviewer/review/reviewCompleted.tpl
@@ -76,36 +76,45 @@ op="fetchGrid" submissionId=$submission->getId() stageId=$reviewAssignment->getS
 <div class="export-certificate-form-container">
     <div class="instructions">{translate key="plugins.generic.exportReviewerCertificate.reviewer.instruction"}</div>
     <div class="separator"></div>
-    <div class="column">
-        <div class="form-group">
-            <label>{translate key="plugins.generic.exportReviewerCertificate.reviewer.title_label"}</label>
-            <input type="text" id="reviewer_title" placeholder="C | Dr | Dra | LI | MC | MRT" />
+    
+    {if $certificateDownloaded}
+        <div class="pkp_notification" style="margin: 10px 0; padding: 10px; background: #f5f5f5; border-left: 4px solid #22d322;">
+            <strong>{translate key="plugins.generic.exportReviewerCertificate.certificate.download"}</strong>
+            <p style="margin: 5px 0 0 0;">{translate key="plugins.generic.exportReviewerCertificate.certificate.alreadyDownloaded"}</p>
+            {if $certificateDownloadDate}
+                <p style="margin: 5px 0 0 0; font-size: 0.9em; color: #666;">
+                    {translate key="plugins.generic.exportReviewerCertificate.certificate.downloadDate" date=$certificateDownloadDate}
+                </p>
+            {/if}
+        </div>
+    {else}
+        <div class="column">
+            <div class="form-group">
+                <label>{translate key="plugins.generic.exportReviewerCertificate.reviewer.title_label"}</label>
+                <input type="text" id="reviewer_title" placeholder="C | Dr | Dra | LI | MC | MRT" />
+            </div>
+        </div>
+    {/if}
+</div>
+
+{if !$certificateDownloaded}
+    <div class="pkp_controllers_grid ">
+        <div class="actions">
+            <a href="{url page="reviewer" op="download" submission=$submission->getId()}"
+                target="_BLANK"
+                title="{translate key="plugins.generic.exportReviewerCertificate.reviewer.button_title"}">{translate
+                key="plugins.generic.exportReviewerCertificate.reviewer.button_label"}</a>
         </div>
     </div>
-</div>
+{/if}
 
-<div class="pkp_controllers_grid ">
-    <div class="actions">
-        <a href="{url page=" reviewer" op="download" submission=$submission->getId()}"
-            target="_BLANK"
-            title="{translate key="plugins.generic.exportReviewerCertificate.reviewer.button_title" }">{translate
-            key="plugins.generic.exportReviewerCertificate.reviewer.button_label"}</a>
-    </div>
-</div>
-
+{if !$certificateDownloaded}
 <script>
-    function showButton(){
-        $('.actions').hide();
-        let activeButton = true;
-        if(activeButton){
-            $('.actions').show();
-        }
-    }
     $('.actions a').on('click',function(){
         let href = $(this).attr('href');
         let params = "";
-        // params += "&reviewer_gender="+$('#reviewer_gender option:selected').val();
         params += "&reviewer_title="+($("#reviewer_title").val() != "" ? $("#reviewer_title").val() : "C. ");
         $(this).attr('href',href+params);
     });
 </script>
+{/if}

--- a/version.xml
+++ b/version.xml
@@ -2,7 +2,7 @@
 <version>
   <application>exportReviewerCertificate</application>
   <type>plugins.generic</type>
-  <release>1.1.5.2</release>
+  <release>1.1.6.0</release>
   <date>2025-01-16</date>
   <lazy-load>1</lazy-load>
   <site-wide>0</site-wide>


### PR DESCRIPTION


Hola @epsomsegura: Comparto esta PR con los ajustes solicitados en la Task-49740-649

## Descripción
Se realizaron ajustes en el repositorio para obtener y gestionar datos considerando futuras actualizaciónes, ademas de implementar las funciones para el guardado en el log de actividad del envió en OJS y la limitación de descarga. 

## Cambios realizados
- Ajustes en repositories/ReviewerCertificateRepository.php
- Asignación de estado para actualización de template reviewCompleted.tpl
- Guardado de registro de actividad 
- Carga de certificado exportado en carpeta de envió
